### PR TITLE
Java 17 and :build-image compatible changes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.2.6.RELEASE</version>
+        <version>2.5.6</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>io.bdemers.dice</groupId>
@@ -15,8 +15,9 @@
     <description>Simple REST Dice Parser</description>
 
     <properties>
-        <java.version>1.8</java.version>
-        <kotlin.version>1.3.71</kotlin.version>
+        <java.version>17</java.version>
+        <maven.compiler.release>${java.version}</maven.compiler.release>
+        <kotlin.version>1.6.0-RC2</kotlin.version>
     </properties>
 
     <dependencies>
@@ -45,7 +46,7 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <artifactId>kotlin-stdlib</artifactId>
         </dependency>
 
         <dependency>
@@ -68,13 +69,28 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <configuration>
-                    <finalName>${project.artifactId}</finalName>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
+
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+
+                    <execution>
+                        <id>test-compile</id>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+
                 <configuration>
                     <args>
                         <arg>-Xjsr305=strict</arg>
@@ -91,6 +107,7 @@
                     </dependency>
                 </dependencies>
             </plugin>
+
         </plugins>
     </build>
 


### PR DESCRIPTION
* Updated spring-boot to support Java 17 and `:build-image` goal
* updated kotlin to 1.6.0 to support Java 17.
* removed `finalName` which is incompatible with `:build-image` (wow!).

Optional change:
* setting `<maven.compiler.version/>`